### PR TITLE
AL - Derive OAuth2 security resource ID from app.namespace

### DIFF
--- a/secrets-heroku.properties.SAMPLE
+++ b/secrets-heroku.properties.SAMPLE
@@ -6,7 +6,7 @@ auth0.clientId=FILL-IN-AUTH0-CLIENT-ID
 
 spring.data.mongodb.uri=FILL-IT-IN
 
-security.oauth2.resource.id=https://YOUR-HEROKU-APP.herokuapp.com
+security.oauth2.resource.id=${app.namespace}
 security.oauth2.resource.jwk.keySetUri=https://${auth0.domain}/.well-known/jwks.json
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/secrets-localhost.properties.SAMPLE
+++ b/secrets-localhost.properties.SAMPLE
@@ -6,5 +6,5 @@ auth0.clientId=FILL-IN-AUTH0-CLIENT-ID
 
 spring.data.mongodb.uri=FILL-IT-IN
 
-security.oauth2.resource.id=https://YOUR-HEROKU-APP.herokuapp.com
+security.oauth2.resource.id=${app.namespace}
 security.oauth2.resource.jwk.keySetUri=https://${auth0.domain}/.well-known/jwks.json


### PR DESCRIPTION
This isn't exactly the same issue that I encountered in proj-ucsb-courses-search, but to avoid errors down the line, I refactored the value for `security.oauth2.resource.id` to come from `app.namespace` instead of from manual entry. This keeps it consistent with the other projects.