### PR TITLE
Use ant instead of maven to copy secrets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,11 +154,12 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>
 						<configuration>
-							<target>
+							<target combine.children="append">
 								<copy todir="${project.build.directory}/classes/public">
 									<fileset dir="${project.basedir}/javascript/build" />
 								</copy>
@@ -256,23 +257,16 @@
 				</resources>
 				<plugins>
 					<plugin>
-						<artifactId>maven-resources-plugin</artifactId>
-						<version>3.1.0</version>
+						<artifactId>maven-antrun-plugin</artifactId>
 						<executions>
 							<execution>
-								<id>copy-resources</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>copy-resources</goal>
-								</goals>
+								<phase>generate-resources</phase>
 								<configuration>
-									<outputDirectory>${basedir}/target/classes</outputDirectory>
-									<resources>
-										<resource>
-											<directory>.</directory>
-											<include>secrets-localhost.properties</include>
-										</resource>
-									</resources>
+									<target>
+										<copy todir="${project.build.directory}/classes">
+											<file file="${project.basedir}/secrets-localhost.properties" />
+										</copy>
+									</target>
 								</configuration>
 							</execution>
 						</executions>


### PR DESCRIPTION
This PR changes the build process to use maven-antrun-plugin instead of maven-resources-plugin to copy the secrets-localhost.properties file. For some reason, maven-resources-plugin performs worse than maven-antrun-plugin when simply copying files, in some cases taking minutes to copy a single file.

In order to support this, we also update to the latest version of maven-antrun-plugin, which allows us to use maven's combine.children feature to properly merge the root and profile configurations of the plugin.