### PR TITLE
jv - remove browser false option in eslint config

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -8,7 +8,6 @@
       {
         "files": ["src/test/**/*.js"],
         "env": {
-          "browser": false,
           "node": true,
           "jest": true
         }


### PR DESCRIPTION
This allows browser environment to be emulated in the tests which makes Eslint not throw errors on global variables like "File". 