### PR TITLE
7pm-1-w21 select tutor component

### DIFF
--- a/src/main/java/edu/ucsb/ucsbcslas/controllers/CourseController.java
+++ b/src/main/java/edu/ucsb/ucsbcslas/controllers/CourseController.java
@@ -246,5 +246,26 @@ public class CourseController {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Malformed CSV", e);
     }
   }
+
+  @GetMapping(value = "/api/public/quarters", produces = "application/json")
+  public ResponseEntity<String> getQuarters() throws JsonProcessingException {
+
+    List <String> quartersList = courseRepository.selectDistinctQuarter();
+    ObjectMapper mapper = new ObjectMapper();
+
+    String body = mapper.writeValueAsString(quartersList);
+    return ResponseEntity.ok().body(body);
+  }
+
+  @GetMapping(value = "/api/public/courses/forQuarter/{qtr}", produces = "application/json")
+  public ResponseEntity<String> getCoursesForQuarter(@PathVariable("qtr") String qtr) throws JsonProcessingException {
+
+    List <Course> courseList = courseRepository.findByQuarter(qtr);
+    ObjectMapper mapper = new ObjectMapper();
+
+    String body = mapper.writeValueAsString(courseList);
+    return ResponseEntity.ok().body(body);
+  }
+
 }
   

--- a/src/main/java/edu/ucsb/ucsbcslas/repositories/CourseRepository.java
+++ b/src/main/java/edu/ucsb/ucsbcslas/repositories/CourseRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import edu.ucsb.ucsbcslas.models.Course;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,4 +17,7 @@ public interface CourseRepository extends CrudRepository<Course, Long> {
   Optional<Course> findByName(String name);
   Optional<Course> findById(Long id);
   List<Course> findByQuarter(String quarter);
+
+  @Query("SELECT DISTINCT quarter FROM Course")
+  List<String> selectDistinctQuarter();
 }

--- a/src/test/java/edu/ucsb/ucsbcslas/controllers/CourseControllerTests.java
+++ b/src/test/java/edu/ucsb/ucsbcslas/controllers/CourseControllerTests.java
@@ -106,6 +106,34 @@ public class CourseControllerTests {
   }
 
   @Test
+  public void testGetQuarters() throws Exception {
+    List<String> expectedQuarters = new ArrayList<String>();
+    when(mockCourseRepository.selectDistinctQuarter()).thenReturn(expectedQuarters);
+    MvcResult response = mockMvc.perform(get("/api/public/quarters").contentType("application/json")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken())).andExpect(status().isOk()).andReturn();
+
+    verify(mockCourseRepository, times(1)).selectDistinctQuarter();
+
+    String responseString = response.getResponse().getContentAsString();
+    List<String> actualQuarters = objectMapper.readValue(responseString, new TypeReference<List<String>>() {});
+    assertEquals(actualQuarters, expectedQuarters);
+  }
+
+  @Test
+  public void testGetCoursesForQuarter() throws Exception {
+    List<Course> expectedCoursesForQuarters = new ArrayList<Course>();
+    when(mockCourseRepository.findByQuarter("1")).thenReturn(expectedCoursesForQuarters);
+    MvcResult response = mockMvc.perform(get("/api/public/courses/forQuarter/1").contentType("application/json")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken())).andExpect(status().isOk()).andReturn();
+
+    verify(mockCourseRepository, times(1)).findByQuarter("1");
+
+    String responseString = response.getResponse().getContentAsString();
+    List<Course> actualCoursesForQuarters = objectMapper.readValue(responseString, new TypeReference<List<Course>>() {});
+    assertEquals(actualCoursesForQuarters, expectedCoursesForQuarters);
+  }
+
+  @Test
   public void testGetASingleCourse() throws Exception {
     Course expectedCourse = new Course(1L, "course 1", "F20", "fname", "lname", "email");
     // mockito is the library that allows us to do this when stuff


### PR DESCRIPTION
PR resolved #167. In this PR, I wrote backend functions and tests for getQuarter and getCoursesForQuarter that help with getting a Tutor Assignment ID for a specific tutor who is tutoring a specific course offered in a specific quarter. This backend functionality can be used to select the tutor component when adding a new office hour slot so that you do not need to go to the tutor assignment page to find the Tutor Assignment ID.